### PR TITLE
Hide deprecated resources by default

### DIFF
--- a/src/AdminBuilder.js
+++ b/src/AdminBuilder.js
@@ -42,6 +42,7 @@ const AdminBuilder = ({children, blacklist, ...props}) => {
             {data.resources
               .filter(
                 resource =>
+                  !resource.deprecated &&
                   !blacklisted.has(resource.name) &&
                   !defined.has(resource.name),
               )


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

They can be added back by adding them explicitly. Example:
```jsx
export default () => (
  <HydraAdmin entrypoint="https://demo.api-platform.com">
    <Resource name="parchments" list={ListGuesser} edit={EditGuesser} />
    <Resource name="reviews" list={ListGuesser} edit={EditGuesser} /> {/* deprecated, added manually */}
  </HydraAdmin>
);
```